### PR TITLE
v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [8.1.0] - 2020-07-27
+### Changed
+- examples are no longer run directly from 'npm scripts' but via `scripts/run-example.js`
+- examples are run in such a manner that the main process is not killed before the child process fully exits
+- the exported `somnus` object is now created via `Object.create(null)`
+
+### Added
+- env var `UNIX_SOCKET` (please see README for details)
+- example code for starting `somnus` on a unix socket
+- unix socket -related test cases
+
 ## [8.0.0] - 2020-07-25
 ### Changed
 - upgraded multiple dependencies, most notably restify@8

--- a/README.md
+++ b/README.md
@@ -54,17 +54,16 @@ npm run build:prod
 import somnus from 'somnus';
 // or const somnus = require('somnus').default;
 
-// you can add route via the standard syntax
+// you can add routes via the standard syntax
 // as you would normally do with `express` or `restify`
 somnus.server.get('/echo', (req, res) => res.send('echo echo'));
 
 // or you can add routes by declaring a `routeConfig` object,
-// which is then passed into `somnus.start()` method
-somnus.start({
-  routeConfig: {
-    'get /hello': (req, res) => res.send('world')
-  }
-});
+// which is then passed into `somnus.start()`
+const routeConfig = {
+  'get /hello': (req, res) => res.send('world')
+}
+somnus.start({ routeConfig });
 
 // from now on, all routes added above are available. Go ahead and test these
 // paths with `curl` or your favourite web browser:
@@ -74,6 +73,7 @@ somnus.start({
 
 ## ENV variables
 
+- `UNIX_SOCKET`: the unix socket at which the underlying `http` server listens, defaults to `undefined`, taking precedence over `HOST` and `PORT` (explained below) when defined
 - `HOST`: the host at which the underlying `http` server listens, defaults to `localhost`
 - `PORT`: the port at which the underlying `http` server listens, defaults to a random available port on your system
 - `LOG_LEVEL`: enum of [bunyan log levels](https://github.com/trentm/node-bunyan#levels). If set, this will overwrite the default value, which is `warn` for production build and `debug` for development build.

--- a/examples/unix-socket/unix-socket-example.ts
+++ b/examples/unix-socket/unix-socket-example.ts
@@ -1,0 +1,17 @@
+import somnus from '../../lib/somnus';
+import { Request, Response } from 'restify';
+
+// this example assumes `process.env.UNIX_SOCKET` was properly provided,
+// you can see `scripts/run-example.js` for related details
+
+somnus.start({
+  routeConfig: {
+    'get /hello-socket': (req: Request, res: Response) => res.send({
+      message: `socket is ${process.env.UNIX_SOCKET}`,
+      details: { 'requestParams': req.params }
+    })
+  }
+});
+
+// now to communicate with the Node.js process via a unix socket, you
+// can set up a reverse proxy, or otherwise use any approach you prefer

--- a/package-lock.json
+++ b/package-lock.json
@@ -2854,6 +2854,11 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
+    "gracefulize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gracefulize/-/gracefulize-1.0.0.tgz",
+      "integrity": "sha512-r8vjjKtmG3ea7cfqbwAoFAIVruTgauOWuWSlJeiKVsMzjyyt9CZfhtZibDlGT6E6r3+8RnC2aSwXAyaooN9Uvw=="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "somnus",
   "description": "Minimal, database-agnostic REST API Framework based on Restify",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "main": "lib/somnus.js",
   "types": "lib/somnus.d.ts",
   "scripts": {
@@ -11,17 +11,19 @@
     "pretest": "npm run tslint",
     "build:prod": "./scripts/build.sh",
     "build": "NODE_ENV=development ./scripts/build.sh",
-    "test:base": "mocha --require ts-node/register --file test/setup.js -R spec test/**/*.ts",
+    "test:base": "mocha --require ts-node/register --file test/setup.js -R spec test/**/*.ts test/*.ts",
     "test:src": "TARGET_DIST_BUILD=false npm run test:base",
     "test:dist": "TARGET_DIST_BUILD=true npm run test:base",
     "test": "npm run test:src && npm run test:dist",
     "prepublishOnly": "npm i; npm run build:prod; npm test",
     "start": "npm run example:helloworld:ts",
-    "example:helloworld:ts": "LOG_LEVEL=info PORT=3001 ts-node examples/helloworld-ts | bunyan -o short",
-    "example:helloworld:js": "LOG_LEVEL=info node examples/helloworld-js | bunyan -o short"
+    "example:helloworld:ts": "./scripts/run-example.js helloworld-ts",
+    "example:helloworld:js": "./scripts/run-example.js helloworld-js",
+    "example:unixsocket": "./scripts/run-example.js unix-socket"
   },
   "dependencies": {
     "bunyan": "^1.8.14",
+    "gracefulize": "^1.0.0",
     "restify": "^8.5.1",
     "restify-errors": "^8.0.2"
   },

--- a/scripts/run-example.js
+++ b/scripts/run-example.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+let cmd = `echo 'Please provide a valid example name'`;
+switch (process.argv[2]) {
+
+  case 'helloworld-js':
+    cmd = `LOG_LEVEL=info node examples/helloworld-js | $(npm bin)/bunyan -o short`;
+    break;
+
+  case 'helloworld-ts':
+    cmd = `LOG_LEVEL=info PORT=3001 $(npm bin)/ts-node examples/helloworld-ts | $(npm bin)/bunyan -o short`;
+    break;
+
+  case 'unix-socket':
+    cmd = `cd examples/unix-socket/; ` +
+      `LOG_LEVEL=info UNIX_SOCKET=example.sock $(npm bin)/ts-node unix-socket-example.ts | $(npm bin)/bunyan -o short`;
+
+  default:
+    break;
+
+}
+
+console.log(`About to run an example for you. Alternatively, you could also run the following command directly:\n${cmd}\n`);
+
+// spawning a shell to execute the given command, piping its outputs to the main process
+const cp = require('child_process').exec(cmd);
+cp.stdout.pipe(process.stdout);
+cp.stderr.pipe(process.stderr);
+
+// this does not affect the examples, we just need it so that any log (if at all)
+// sent from the child process is properly displayed by the main process before the
+// main process itself is killed
+process.once('SIGINT', () => {
+  console.log(`SIGINT on ${process.pid} :: waiting for the shell process ${cp.pid} to exit...`);
+});

--- a/test/somnus-import.spec.ts
+++ b/test/somnus-import.spec.ts
@@ -8,24 +8,24 @@ import Somnus2 from '../src/somnus';
 
 describe('somnus multiple imports', () => {
 
-    it('should instantiate a single Restify Server instance ever', () => {
-        assert(Somnus1.server === Somnus2.server);
-    });
+  it('should instantiate a single Restify Server instance ever', () => {
+    assert(Somnus1.server === Somnus2.server);
+  });
 
-    describe('import from source', () => {
-        it('should support the dynamic import API', async () => {
-            const module = await import('../src/somnus');
-            assert(module.somnus.server === Somnus1.server);
-            assert(module.somnus.server === Somnus2.server);
-        });
+  describe('import from source', () => {
+    it('should support the dynamic import API', async () => {
+      const module = await import('../src/somnus');
+      assert(module.somnus.server === Somnus1.server);
+      assert(module.somnus.server === Somnus2.server);
     });
+  });
 
-    describe('import from dist', () => {
-        it('should support the dynamic import API', async () => {
-            const { somnus: somnus1 } = await import('../lib/somnus') as any;
-            const { somnus: somnus2 } = await import('../lib/somnus') as any;
-            assert(somnus1.server === somnus2.server);
-        });
+  describe('import from dist', () => {
+    it('should support the dynamic import API', async () => {
+      const { somnus: somnus1 } = await import('../lib/somnus') as any;
+      const { somnus: somnus2 } = await import('../lib/somnus') as any;
+      assert(somnus1.server === somnus2.server);
     });
+  });
 
 });

--- a/test/unix-socket/start-socket-bound-somnus.js
+++ b/test/unix-socket/start-socket-bound-somnus.js
@@ -18,6 +18,7 @@ const routeConfig = {
 
 async function main() {
 
+  // we can ensure the `import()` syntax is supported in older Node.js versions by using the `--experimental-modules` flag
   mod = await import(modulePath);
 
   // module cache busting so we get a clean import on the next test suite, which isn't 'polluted' by `process.env.UNIX_SOCKET`

--- a/test/unix-socket/start-socket-bound-somnus.js
+++ b/test/unix-socket/start-socket-bound-somnus.js
@@ -1,0 +1,33 @@
+// tslint:disable-next-line
+const path = require('path');
+
+// @NOTE that right now this works only with dist build, and will fail with src (due to the complex nature of IPC + ts-node)
+const targetDistBuild = process.env.TARGET_DIST_BUILD === 'true';
+const moduleFile = targetDistBuild ? '../../lib/somnus.js' : '../../src/somnus';
+const modulePath = path.resolve(__dirname, moduleFile);
+
+let mod;
+
+// module cache busting so we get a clean import for this test suite, which 'reloads' the new `process.env.UNIX_SOCKET`
+// that is set by this test (see more below)
+delete require.cache[require.resolve(modulePath)];
+
+const routeConfig = {
+  'get /hello': (req, res) => res.send('world')
+};
+
+async function main() {
+
+  mod = await import(modulePath);
+
+  // module cache busting so we get a clean import on the next test suite, which isn't 'polluted' by `process.env.UNIX_SOCKET`
+  // that was set in this test
+  delete require.cache[require.resolve(modulePath)];
+
+  mod.default.somnus.start({ routeConfig }, addr => {
+    process.send({ addr });
+  });
+
+}
+
+main();

--- a/test/unix-socket/unix-socket.spec.ts
+++ b/test/unix-socket/unix-socket.spec.ts
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+import { fork, ChildProcess } from 'child_process';
+
+const TEST_UNIX_SOCKET: string = './test.socket';
+
+function spawnSomnusServerAsChildProcess(): ChildProcess {
+
+  // tslint:disable-next-line:no-console
+  // console.log(`starting child process with ${process.argv[0]}`);
+
+  const modulePath = `${__dirname}/start-socket-bound-somnus.js`;
+  return fork(modulePath, {
+    execPath: process.argv[0],
+    execArgv: [],
+    env: {
+
+      UNIX_SOCKET: TEST_UNIX_SOCKET,
+
+      // @NOTE that right now this works only with dist build, and will fail with src (due to the complex nature of IPC + ts-node)
+      TARGET_DIST_BUILD: 'true', // process.env.TARGET_DIST_BUILD,
+
+      LOG_LEVEL: 'warn'
+
+    }
+  });
+
+}
+
+describe('somnus server listening to unix sockets', () => {
+
+  let proc: ChildProcess;
+
+  after((done) => {
+    if (!proc.killed) {
+      proc.once('exit', () => done());
+      proc.kill('SIGINT');
+    } else {
+      done();
+    }
+  });
+
+  it('should start successfully', (done) => {
+
+    proc = spawnSomnusServerAsChildProcess();
+    proc.on('message', m => {
+      assert.equal((m as any).addr, TEST_UNIX_SOCKET, 'somnus server must listen at the designated unix socket');
+      done();
+    });
+
+  });
+
+  it('should stop gracefully when being killed unexpectedly (e.g. SIGINT)', (done) => {
+    proc.once('exit', () => done());
+    proc.kill('SIGINT');
+  });
+
+  // @TODO assert that the socket `TEST_UNIX_SOCKET` no longer exists?
+
+  it('should start successfully again on the same socket (because it exited gracefully earlier)', (done) => {
+
+    proc = spawnSomnusServerAsChildProcess();
+    proc.on('message', m => {
+      assert.equal((m as any).addr, TEST_UNIX_SOCKET, 'somnus server must listen at the designated unix socket');
+      done();
+    });
+
+  });
+
+});

--- a/test/unix-socket/unix-socket.spec.ts
+++ b/test/unix-socket/unix-socket.spec.ts
@@ -11,7 +11,7 @@ function spawnSomnusServerAsChildProcess(): ChildProcess {
   const modulePath = `${__dirname}/start-socket-bound-somnus.js`;
   return fork(modulePath, {
     execPath: process.argv[0],
-    execArgv: [],
+    execArgv: ['--experimental-modules'],
     env: {
 
       UNIX_SOCKET: TEST_UNIX_SOCKET,


### PR DESCRIPTION
## [8.1.0] - 2020-07-27
### Changed
- examples are no longer run directly from 'npm scripts' but via `scripts/run-example.js`
- examples are run in such a manner that the main process is not killed before the child process fully exits
- the exported `somnus` object is now created via `Object.create(null)`

### Added
- env var `UNIX_SOCKET` (please see README for details)
- example code for starting `somnus` on a unix socket
- unix socket -related test cases